### PR TITLE
Add Creative Power Source (Small Internal Mech Power refactor)

### DIFF
--- a/src/main/generated/assets/bwt/lang/en_us.json
+++ b/src/main/generated/assets/bwt/lang/en_us.json
@@ -79,6 +79,7 @@
   "block.bwt.companion_slab": "Companion Slab",
   "block.bwt.concentrated_hellfire_block": "Concentrated Hellfire Block",
   "block.bwt.corner": "Corner",
+  "block.bwt.creative_power_source": "Creative Power Source",
   "block.bwt.crimson_planks_column": "Crimson Column",
   "block.bwt.crimson_planks_corner": "Crimson Corner",
   "block.bwt.crimson_planks_moulding": "Crimson Moulding",

--- a/src/main/generated/assets/bwt/models/item/creative_power_source.json
+++ b/src/main/generated/assets/bwt/models/item/creative_power_source.json
@@ -1,0 +1,3 @@
+{
+  "parent": "bwt:block/creative_power_source"
+}

--- a/src/main/java/com/bwt/blocks/AxlePowerSourceBlock.java
+++ b/src/main/java/com/bwt/blocks/AxlePowerSourceBlock.java
@@ -3,6 +3,7 @@ package com.bwt.blocks;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
 import net.minecraft.world.World;
 
 public class AxlePowerSourceBlock extends AxleBlock {
@@ -11,19 +12,10 @@ public class AxlePowerSourceBlock extends AxleBlock {
         this.setDefaultState(this.getDefaultState().with(MECH_POWER, 3));
     }
 
-//    @Override
-//    public BlockEntity createBlockEntity(BlockPos pos, BlockState state) {
-//        BetterWithTime.LOGGER.info("Adding block entity");
-//        return new WindmillBlockEntity(pos, state);
-//    }
-
-//    @Override
-//    public <T extends BlockEntity> BlockEntityTicker<T> getTicker(World world, BlockState state, BlockEntityType<T> type) {
-//        if (type.equals(BwtEntities.windmillBlockEntity)) {
-//            return (world1, pos, state1, be) -> WindmillBlockEntity.tick(world1, pos, state1, ((WindmillBlockEntity) be));
-//        }
-//        return null;
-//    }
+    @Override
+    public boolean canRepeatPower(BlockState blockState, Direction direction) {
+        return blockState.get(AXIS) == direction.getAxis() && blockState.get(MECH_POWER) > 0;
+    }
 
     @Override
     public void neighborUpdate(BlockState state, World world, BlockPos pos, Block sourceBlock, BlockPos sourcePos, boolean notify) {

--- a/src/main/java/com/bwt/blocks/BwtBlocks.java
+++ b/src/main/java/com/bwt/blocks/BwtBlocks.java
@@ -49,6 +49,7 @@ public class BwtBlocks implements ModInitializer {
             .nonOpaque()
     );
     public static final Block axlePowerSourceBlock = new AxlePowerSourceBlock(AbstractBlock.Settings.copy(axleBlock));
+    public static final Block creativePowerSourceBlock = new CreativePowerSource(AbstractBlock.Settings.copy(Blocks.OAK_PLANKS).hardness(2F));
 //	public static final Block barrelBlock = new BarrelBlock(AbstractBlock.Settings.create());
 	public static final Block bellowsBlock = new BellowsBlock(AbstractBlock.Settings.copy(Blocks.OAK_PLANKS));
 	public static final BlockDispenserBlock blockDispenserBlock = new BlockDispenserBlock(AbstractBlock.Settings.copy(Blocks.DISPENSER)
@@ -265,6 +266,8 @@ public class BwtBlocks implements ModInitializer {
         Registry.register(Registries.BLOCK, Id.of("axle"), axleBlock);
         Registry.register(Registries.ITEM, Id.of("axle"), new BlockItem(axleBlock, new Item.Settings()));
         Registry.register(Registries.BLOCK, Id.of("axle_power_source"), axlePowerSourceBlock);
+        Registry.register(Registries.BLOCK, Id.of("creative_power_source"), creativePowerSourceBlock);
+        Registry.register(Registries.ITEM, Id.of("creative_power_source"), new BlockItem(creativePowerSourceBlock, new Item.Settings()));
         // Gearbox
         Registry.register(Registries.BLOCK, Id.of("gear_box"), gearBoxBlock);
         Registry.register(Registries.ITEM, Id.of("gear_box"), new BlockItem(gearBoxBlock, new Item.Settings()));

--- a/src/main/java/com/bwt/blocks/CreativePowerSource.java
+++ b/src/main/java/com/bwt/blocks/CreativePowerSource.java
@@ -1,0 +1,42 @@
+package com.bwt.blocks;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.ShapeContext;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+import net.minecraft.util.shape.VoxelShape;
+import net.minecraft.util.shape.VoxelShapes;
+import net.minecraft.world.BlockView;
+
+public class CreativePowerSource extends Block implements IMechPowerBlock {
+
+    protected static final VoxelShape X_SHAPE = Block.createCuboidShape(0f, 6f, 6f, 16f, 10f, 10f);
+    protected static final VoxelShape Y_SHAPE = Block.createCuboidShape(6f, 0f, 6f, 10f, 16f, 10f);
+    protected static final VoxelShape Z_SHAPE = Block.createCuboidShape(6f, 6f, 0f, 10f, 10f, 16f);
+
+
+    public CreativePowerSource(Settings settings) {
+        super(settings);
+    }
+
+    @Override
+    public boolean canRepeatPower(BlockState blockState, Direction direction) {
+        return true;
+    }
+
+    @Override
+    public boolean canTransferPower(BlockState blockState, Direction direction) {
+        return true;
+    }
+
+    @Override
+    public boolean isMechPowered(BlockState blockState) {
+        return true;
+    }
+
+    @Override
+    public VoxelShape getOutlineShape(BlockState state, BlockView world, BlockPos pos, ShapeContext ctx) {
+        return VoxelShapes.union(X_SHAPE, Y_SHAPE, Z_SHAPE);
+    }
+}

--- a/src/main/java/com/bwt/blocks/GearBoxBlock.java
+++ b/src/main/java/com/bwt/blocks/GearBoxBlock.java
@@ -26,6 +26,7 @@ import net.minecraft.world.BlockView;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldAccess;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 import java.util.function.Predicate;
@@ -64,11 +65,10 @@ public class GearBoxBlock extends SimpleFacingBlock implements MechPowerBlockBas
     }
 
     @Override
-    public boolean isMechPowered(BlockState blockState) {
-        return MechPowerBlockBase.super.isMechPowered(blockState) && !blockState.get(POWERED);
+    public boolean canRepeatPower(BlockState blockState, @Nullable Direction direction) {
+        // not the direction the gearbox is getting power from
+        return blockState.get(FACING) != direction;
     }
-
-
 
     @Override
     public void randomDisplayTick(BlockState state, World world, BlockPos pos, Random random) {

--- a/src/main/java/com/bwt/blocks/IMechPowerBlock.java
+++ b/src/main/java/com/bwt/blocks/IMechPowerBlock.java
@@ -1,0 +1,25 @@
+package com.bwt.blocks;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.state.property.BooleanProperty;
+import net.minecraft.util.math.Direction;
+
+public interface IMechPowerBlock {
+    BooleanProperty MECH_POWERED = BooleanProperty.of("mech_powered");
+
+    default boolean isMechPowered(BlockState blockState) {
+        return blockState.get(MECH_POWERED);
+    }
+
+    default boolean canRepeatPower(BlockState blockState, Direction direction) {
+        return false;
+    }
+
+    default boolean canTransferPower(BlockState blockState, Direction direction) {
+        return false;
+    }
+
+    default int getMechPower(BlockState blockState) {
+        return 0;
+    }
+}

--- a/src/main/java/com/bwt/generation/LangGenerator.java
+++ b/src/main/java/com/bwt/generation/LangGenerator.java
@@ -88,6 +88,7 @@ public class LangGenerator extends FabricLanguageProvider {
         translationBuilder.add(BwtItems.breedingHarnessItem, "Breeding Harness");
         translationBuilder.add(BwtItems.netheriteMattockItem, "Netherite Mattock");
         translationBuilder.add(BwtItems.netheriteBattleAxeItem, "Netherite Battle Axe");
+        translationBuilder.add(BwtBlocks.creativePowerSourceBlock, "Creative Power Source");
 
         // Load an existing language file.
         try {

--- a/src/main/java/com/bwt/generation/ModelGenerator.java
+++ b/src/main/java/com/bwt/generation/ModelGenerator.java
@@ -209,6 +209,7 @@ public class ModelGenerator extends FabricModelProvider {
         blockStateModelGenerator.registerParentedItemModel(BwtBlocks.unfiredVaseBlock, ModelIds.getBlockModelId(BwtBlocks.unfiredVaseBlock));
         blockStateModelGenerator.registerParentedItemModel(BwtBlocks.unfiredUrnBlock, ModelIds.getBlockModelId(BwtBlocks.unfiredUrnBlock));
         blockStateModelGenerator.registerParentedItemModel(BwtBlocks.vineTrapBlock, ModelIds.getBlockModelId(BwtBlocks.vineTrapBlock));
+        blockStateModelGenerator.registerParentedItemModel(BwtBlocks.creativePowerSourceBlock, ModelIds.getBlockModelId(BwtBlocks.creativePowerSourceBlock));
         blockStateModelGenerator.registerItemModel(BwtBlocks.urnBlock.asItem());
     }
 
@@ -267,6 +268,7 @@ public class ModelGenerator extends FabricModelProvider {
         itemModelGenerator.register(BwtItems.windmillItem, Models.GENERATED);
         itemModelGenerator.register(BwtItems.wolfChopItem, Items.PORKCHOP, Models.GENERATED);
         itemModelGenerator.register(BwtItems.woodBladeItem, Models.GENERATED);
+
     }
 
     private void generateBloodWoodBlocks(BlockStateModelGenerator blockStateModelGenerator) {

--- a/src/main/resources/assets/bwt/blockstates/creative_power_source.json
+++ b/src/main/resources/assets/bwt/blockstates/creative_power_source.json
@@ -1,0 +1,5 @@
+{
+  "variants": {
+    "": { "model": "bwt:block/creative_power_source"}
+  }
+}

--- a/src/main/resources/assets/bwt/models/block/creative_power_source.json
+++ b/src/main/resources/assets/bwt/models/block/creative_power_source.json
@@ -1,0 +1,73 @@
+{
+	"credit": "Made with Blockbench",
+	"parent": "block/block",
+	"textures": {
+		"particle": "bwt:block/axle_body",
+		"body": "bwt:block/axle_body",
+		"head": "bwt:block/axle_head"
+	},
+	"elements": [
+		{
+			"from": [6, 6, 0],
+			"to": [10, 10, 16],
+			"faces": {
+				"north": {"uv": [6, 6, 10, 10], "texture": "#head", "cullface": "north"},
+				"east": {"uv": [0, 0, 16, 4], "texture": "#body"},
+				"south": {"uv": [6, 6, 10, 10], "texture": "#head", "cullface": "south"},
+				"west": {"uv": [0, 4, 16, 8], "texture": "#body"},
+				"up": {"uv": [0, 8, 16, 12], "rotation": 270, "texture": "#body"},
+				"down": {"uv": [0, 12, 16, 16], "rotation": 90, "texture": "#body"}
+			}
+		},
+		{
+			"from": [10, 6, 6],
+			"to": [16, 10, 10],
+			"faces": {
+				"north": {"uv": [0, 4, 6, 8], "texture": "#body"},
+				"east": {"uv": [6, 6, 10, 10], "texture": "#head", "cullface": "north"},
+				"south": {"uv": [0, 0, 6, 4], "texture": "#body"},
+				"west": {"uv": [6, 6, 10, 10], "texture": "#head", "cullface": "south"},
+				"up": {"uv": [0, 8, 6, 12], "texture": "#body"},
+				"down": {"uv": [0, 12, 6, 16], "texture": "#body"}
+			}
+		},
+		{
+			"from": [0, 6, 6],
+			"to": [6, 10, 10],
+			"rotation": {"angle": 0, "axis": "y", "origin": [16, 0, 0]},
+			"faces": {
+				"north": {"uv": [10, 4, 16, 8], "texture": "#body"},
+				"east": {"uv": [6, 6, 10, 10], "texture": "#head", "cullface": "north"},
+				"south": {"uv": [10, 0, 16, 4], "texture": "#body"},
+				"west": {"uv": [6, 6, 10, 10], "texture": "#head", "cullface": "south"},
+				"up": {"uv": [10, 8, 16, 12], "texture": "#body"},
+				"down": {"uv": [10, 12, 16, 16], "texture": "#body"}
+			}
+		},
+		{
+			"from": [6, 10, 6],
+			"to": [10, 16, 10],
+			"faces": {
+				"north": {"uv": [0, 12, 6, 16], "rotation": 270, "texture": "#body"},
+				"east": {"uv": [0, 0, 6, 4], "rotation": 270, "texture": "#body"},
+				"south": {"uv": [0, 8, 6, 12], "rotation": 270, "texture": "#body"},
+				"west": {"uv": [0, 4, 6, 8], "rotation": 90, "texture": "#body"},
+				"up": {"uv": [6, 6, 10, 10], "rotation": 180, "texture": "#head", "cullface": "north"},
+				"down": {"uv": [6, 6, 10, 10], "texture": "#head", "cullface": "south"}
+			}
+		},
+		{
+			"from": [6, 0, 6],
+			"to": [10, 6, 10],
+			"rotation": {"angle": 0, "axis": "z", "origin": [0, -10, 0]},
+			"faces": {
+				"north": {"uv": [0, 12, 6, 16], "rotation": 270, "texture": "#body"},
+				"east": {"uv": [0, 0, 6, 4], "rotation": 270, "texture": "#body"},
+				"south": {"uv": [0, 8, 6, 12], "rotation": 270, "texture": "#body"},
+				"west": {"uv": [0, 4, 6, 8], "rotation": 90, "texture": "#body"},
+				"up": {"uv": [6, 6, 10, 10], "rotation": 180, "texture": "#head", "cullface": "north"},
+				"down": {"uv": [6, 6, 10, 10], "texture": "#head", "cullface": "south"}
+			}
+		}
+	]
+}


### PR DESCRIPTION
Add an all-directional creative power source block
To accomplish this, some internal reworks for mechanical power were necessary (since it was previously Axis based.
I made it more interface driven. 
There's still some stuff that references axles and gearboxes directly, but most things are now based on IMechPowerBlock. Handcranks are still direct reference based.

IMechPowerBlock.canTransferPower is used for lossy transfer (axle) IMechPowerBlock.canRepeatPower is used for things like GearBoxes which will reset to make power or output power.