### PR TITLE
Fixes #13 

### DIFF
--- a/src/main/java/com/bwt/blocks/HibachiBlock.java
+++ b/src/main/java/com/bwt/blocks/HibachiBlock.java
@@ -4,7 +4,6 @@ import com.bwt.sounds.BwtSoundEvents;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
-import net.minecraft.block.FireBlock;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.item.ItemPlacementContext;
 import net.minecraft.item.ItemStack;
@@ -60,6 +59,8 @@ public class HibachiBlock extends Block {
                 world.playSound(null, pos, BwtSoundEvents.HIBACHI_IGNITE,
                         SoundCategory.BLOCKS, 1F, world.random.nextFloat() * 0.4F + 1F);
                 world.setBlockState(pos.up(), Blocks.FIRE.getDefaultState());
+            } else {
+                world.playSound(null, pos, SoundEvents.BLOCK_FIRE_EXTINGUISH, SoundCategory.BLOCKS, 0.5F, 1.6F + (world.random.nextFloat() - world.random.nextFloat()) * 0.8F);
             }
         }
         else {

--- a/src/main/java/com/bwt/blocks/StokedFireBlock.java
+++ b/src/main/java/com/bwt/blocks/StokedFireBlock.java
@@ -73,7 +73,7 @@ public class StokedFireBlock extends AbstractFireBlock {
 
     @Override
     protected boolean isFlammable(BlockState state) {
-        return true;
+        return FlammableBlockRegistry.getDefaultInstance().get(state.getBlock()).getBurnChance() > 0;
     }
 
 


### PR DESCRIPTION
by changing StokedFireBlock::isFlammable to use the FlammabilityRegistry. This means the Hibachi will destroy ANY flammable block directly above it to crete the fire block.  Hibachi will also make a negative noise when it cannot start due to the block above it.